### PR TITLE
Removing some undefineds

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 // TIP: You can run 'node example.js' in the project directory to see the output in your terminal!
 
-const {logger, stdoutHandler} = require('.');
+const { logger, stdoutHandler } = require('.');
 
 const xa = logger();
 
@@ -10,7 +10,7 @@ xa.info('SUCCESS', 'Finished converting file!');
 
 xa.warn(
 	'WARN',
-	`This module is deprecated! Read more: ${xa.link('http://example.com','example.com')}`
+	`This module is deprecated! Read more: ${xa.link('http://example.com', 'example.com')}`
 );
 
 xa.experimental('EXPERIMENTAL', 'This feature is not implemented yet!');

--- a/example.js
+++ b/example.js
@@ -10,7 +10,7 @@ xa.info('SUCCESS', 'Finished converting file!');
 
 xa.warn(
 	'WARN',
-	`This module is deprecated! Read more: ${xa.link('http://example.com')}`
+	`This module is deprecated! Read more: ${xa.link('http://example.com','example.com')}`
 );
 
 xa.experimental('EXPERIMENTAL', 'This feature is not implemented yet!');
@@ -19,7 +19,7 @@ xa.on('ON', 'You turned on unicorn mode!');
 
 xa.off('OFF', 'You turned off unicorn mode!');
 
-xa.error('Could not find chalk. Make sure you have installed it!');
+xa.error('Could not find chalk.', 'Make sure you have installed it!');
 
 const customizedLogger = logger({
 	handlers: [


### PR DESCRIPTION
 I could not fix the undefined of 
	``` `This module is deprecated! Read more: ${xa.link('http://example.com','example.com')}` ```
because the `${}` part is showed before the phrase, and i did not understand why.